### PR TITLE
Replace CsvHelper with DataFrame for the CSV Reader

### DIFF
--- a/src/Data.Common/DataSource/FileSystemDataSource.cs
+++ b/src/Data.Common/DataSource/FileSystemDataSource.cs
@@ -1,6 +1,4 @@
-﻿using SqlBuildingBlocks;
-
-namespace Data.Common.DataSource;
+﻿namespace Data.Common.DataSource;
 
 /// <summary>
 /// Provides a data source implementation for file system-based storage.
@@ -69,7 +67,7 @@ public class FileSystemDataSource : IDataSourceProvider
     /// <param name="tableName">The name of the table.</param>
     /// <returns>A <see cref="TextReader"/> for reading the table data.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the data source type is not supported.</exception>
-    public TextReader GetTextReader(string tableName) => DataSourceType switch
+    public StreamReader GetTextReader(string tableName) => DataSourceType switch
     {
         DataSourceType.Directory => GetTextReader_FolderAsDB(tableName),
         DataSourceType.File => GetTextReader_FileAsDB(),
@@ -152,7 +150,7 @@ public class FileSystemDataSource : IDataSourceProvider
     /// </summary>
     public event DataSourceEventHandler Changed;
 
-    private TextReader GetTextReader_FolderAsDB(string tableName)
+    private StreamReader GetTextReader_FolderAsDB(string tableName)
     {
         var pathToTableFile = GetTablePath(tableName);
         return GetTextReaderFromFilePath(pathToTableFile);
@@ -161,9 +159,9 @@ public class FileSystemDataSource : IDataSourceProvider
     private void FileWatcher_Changed(object sender, FileSystemEventArgs e) =>
         Changed?.Invoke(sender, new DataSourceEventArgs(Path.GetFileNameWithoutExtension(e.FullPath)));
 
-    private TextReader GetTextReader_FileAsDB() => GetTextReaderFromFilePath(path);
+    private StreamReader GetTextReader_FileAsDB() => GetTextReaderFromFilePath(path);
 
-    private TextReader GetTextReaderFromFilePath(string path)
+    private StreamReader GetTextReaderFromFilePath(string path)
     {
         // Open the file stream
         FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);

--- a/src/Data.Common/DataSource/IDataSourceProvider.cs
+++ b/src/Data.Common/DataSource/IDataSourceProvider.cs
@@ -29,7 +29,7 @@ public interface IDataSourceProvider
     /// </summary>
     /// <param name="tableName">The name of the table.</param>
     /// <returns>A <see cref="TextReader"/> for reading the table data.</returns>
-    TextReader GetTextReader(string tableName);
+    StreamReader GetTextReader(string tableName);
 
     /// <summary>
     /// Gets a <see cref="TextWriter"/> to write data to the specified table.

--- a/src/Data.Common/DataSource/StreamedDataSource.cs
+++ b/src/Data.Common/DataSource/StreamedDataSource.cs
@@ -67,14 +67,13 @@ public class StreamedDataSource : IDataSourceProvider
     /// <param name="tableName">The name of the table to read.</param>
     /// <returns>A <see cref="TextReader"/> for reading the table data.</returns>
     /// <exception cref="FileNotFoundException">Thrown if the specified table does not exist in the data source.</exception>
-    public TextReader GetTextReader(string tableName)
+    public StreamReader GetTextReader(string tableName)
     {
         if (tables.TryGetValue(tableName, out Stream tableData) && tableData is not null)
         {
             tableData.Position = 0;
             return new StreamReader(tableData, Encoding.UTF8, true, 1024, true);
         }
-            
 
         throw new FileNotFoundException($"No table stream for {tableName}.");
     }

--- a/src/Data.Csv/Utils/CsvTransformStream.cs
+++ b/src/Data.Csv/Utils/CsvTransformStream.cs
@@ -1,0 +1,139 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+/// <summary>
+/// A custom stream wrapper that preprocesses a CSV data stream to ensure consistent column counts
+/// in each row based on the header row's column count.
+/// 
+/// This class reads lines of text from an underlying stream (such as the BaseStream of a StreamReader),
+/// checks each line for the number of commas, and appends additional commas to lines with fewer commas
+/// than the header row. This ensures that all rows have the same number of columns as the header row,
+/// which is especially useful for handling malformed CSV files.
+/// 
+/// Key Features:
+/// - Reads the CSV header row during initialization to determine the expected number of columns.
+/// - Transparently transforms subsequent rows as they are read, appending commas if necessary.
+/// - Supports efficient, line-by-line processing for handling large streams without loading the entire
+///   file into memory.
+/// 
+/// Usage:
+/// - Wrap an existing stream (e.g., a FileStream or the BaseStream of a StreamReader) with this class.
+/// - Pass this transformed stream to methods such as DataFrame.LoadCsv for CSV parsing.
+/// 
+/// Limitations:
+/// - This class does not support seeking or writing operations.
+/// - The underlying stream must contain UTF-8 encoded text data.
+/// </summary>
+public class CsvTransformStream : Stream
+{
+    private StreamReader streamReader;
+    private MemoryStream bufferStream;
+    private int expectedCommaCount;
+    private long logicalPosition;
+
+    public string HeaderLine { get; private set; }
+
+    public CsvTransformStream(StreamReader streamReader)
+    {
+        this.streamReader = streamReader ?? throw new ArgumentNullException(nameof(streamReader));
+        bufferStream = new MemoryStream();
+        logicalPosition = 0;
+    }
+
+    private void InitializeHeader()
+    {
+        // Read the first line (header) to determine the number of commas
+        HeaderLine = streamReader.ReadLine();
+        if (string.IsNullOrEmpty(HeaderLine))
+        {
+            throw new InvalidOperationException("CSV stream is empty or header is missing.");
+        }
+
+        expectedCommaCount = HeaderLine.Split(',').Length;
+        WriteToBuffer(HeaderLine + "\n");
+    }
+
+    private void WriteToBuffer(string line)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(line);
+        bufferStream.Write(bytes, 0, bytes.Length);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        // Refill the buffer with transformed lines
+        bufferStream.SetLength(0);
+        bufferStream.Position = 0;
+
+        if (string.IsNullOrEmpty(HeaderLine))
+        {
+            //Read the header line JIT
+            InitializeHeader();
+        }
+
+        if (bufferStream.Length < count)
+        {
+            string line;
+            while ((line = streamReader.ReadLine()) != null)
+            {
+                int commaCount = line.Split(',').Length;
+                if (commaCount < expectedCommaCount)
+                {
+                    line += new string(',', expectedCommaCount - commaCount);
+                }
+
+                WriteToBuffer(line + "\n");
+
+                // Stop refilling the buffer if it has enough data to satisfy the read
+                if (bufferStream.Length >= count)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (bufferStream.Length == 0)
+        {
+            // End of the underlying stream
+            return 0;
+        }
+
+        // Read from the buffer
+        bufferStream.Position = 0;
+        int bytesRead = bufferStream.Read(buffer, offset, count);
+        logicalPosition += bytesRead; // Update logical position
+        bufferStream.Position = bytesRead;
+
+        Debug.WriteLine($"bytesRead = {bytesRead}");
+        var bufferValue = Encoding.UTF8.GetString(buffer);
+        Debug.WriteLine($"{bufferValue}({bufferValue.Length})");
+
+        return bytesRead;
+    }
+
+    // Required overrides for a Stream
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => streamReader.BaseStream.Length;
+    public override long Position
+    {
+        get => logicalPosition;
+        set => throw new NotSupportedException();
+    }
+    public override void Flush() => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        if (origin != SeekOrigin.Begin && offset != 0)
+            throw new NotSupportedException();
+
+        Debug.WriteLine("SEEK to 0");
+        streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
+        HeaderLine = null;
+
+        return 0;
+    }
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/Data.Csv/Utils/CsvTransformStream.cs
+++ b/src/Data.Csv/Utils/CsvTransformStream.cs
@@ -104,10 +104,6 @@ public class CsvTransformStream : Stream
         logicalPosition += bytesRead; // Update logical position
         bufferStream.Position = bytesRead;
 
-        Debug.WriteLine($"bytesRead = {bytesRead}");
-        var bufferValue = Encoding.UTF8.GetString(buffer);
-        Debug.WriteLine($"{bufferValue}({bufferValue.Length})");
-
         return bytesRead;
     }
 
@@ -127,7 +123,6 @@ public class CsvTransformStream : Stream
         if (origin != SeekOrigin.Begin && offset != 0)
             throw new NotSupportedException();
 
-        Debug.WriteLine("SEEK to 0");
         streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
         HeaderLine = null;
 

--- a/tests/Data.Csv.Tests/Data.Csv.Tests.csproj
+++ b/tests/Data.Csv.Tests/Data.Csv.Tests.csproj
@@ -58,6 +58,9 @@
     <None Update="Sources\GettingStarted\Posts.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Sources\sample.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/Data.Csv.Tests/Sources/sample.csv
+++ b/tests/Data.Csv.Tests/Sources/sample.csv
@@ -1,0 +1,6 @@
+CompanyName, CompanyRegion, NumberOfEmployees
+TechCorp, Europe, 250
+Innovate Ltd, America, 1200
+Global Solutions, Asia, 560
+NextGen, Europe, 430
+Alpha Group, America, 800


### PR DESCRIPTION
DataFrame could be used not only to determine the data types of the columns in CSV data, but also to load data.  Therefore its use has been removed its use in reading CSV data streams.  Note though that although, it was removed for reading, CsvHelper is still used for writing.