### PR TITLE
#80 JSON provider: CREATE TABLE followed by INSERT fails

### DIFF
--- a/src/Data.Json/JsonIO/Write/JsonInsert.cs
+++ b/src/Data.Json/JsonIO/Write/JsonInsert.cs
@@ -14,6 +14,10 @@ internal class JsonInsert : FileInsertWriter
 
     protected override void RealizeSchema(DataTable dataTable)
     {
+        //Check to see if the schema has already been defined (this happens in the case that a CREATE TABLE was executed for a JsonCommand)
+        if (dataTable.Columns.Count > 0)
+            return;
+
         //Add missing columns, since we can now determine the schema
 
         foreach (var val in fileStatement.GetValues())

--- a/tests/Data.Csv.Tests/FolderAsDatabase/CsvCreateTableTests.cs
+++ b/tests/Data.Csv.Tests/FolderAsDatabase/CsvCreateTableTests.cs
@@ -17,4 +17,12 @@ public class CsvCreateTableTests
 
     }
 
+    [Fact]
+    public void CreateTable_FollowedByInsert_ShouldWork()
+    {
+        var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+        CreateTableTests.CreateTable_FollowedByInsert_ShouldWork(
+                       () => new CsvConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+
+    }
 }

--- a/tests/Data.Json.Tests/FileAsDatabase/JsonCreateTableTests.cs
+++ b/tests/Data.Json.Tests/FileAsDatabase/JsonCreateTableTests.cs
@@ -21,4 +21,13 @@ public class JsonCreateTableTests
                        () => new JsonConnection(ConnectionStrings.Instance.FileAsDB.Sandbox("Sandbox", sandboxId)));
 
     }
+
+    [Fact]
+    public void CreateTable_FollowedByInsert_ShouldWork()
+    {
+        var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+        CreateTableTests.CreateTable_FollowedByInsert_ShouldWork(
+                       () => new JsonConnection(ConnectionStrings.Instance.FileAsDB.Sandbox("Sandbox", sandboxId)));
+
+    }
 }

--- a/tests/Data.Json.Tests/FolderAsDatabase/JsonCreateTableTests.cs
+++ b/tests/Data.Json.Tests/FolderAsDatabase/JsonCreateTableTests.cs
@@ -17,4 +17,12 @@ public class JsonCreateTableTests
 
     }
 
+    [Fact]
+    public void CreateTable_FollowedByInsert_ShouldWork()
+    {
+        var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+        CreateTableTests.CreateTable_FollowedByInsert_ShouldWork(
+                       () => new JsonConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+
+    }
 }

--- a/tests/Data.Xml.Tests/FileAsDatabase/XmlCreateTableTests.cs
+++ b/tests/Data.Xml.Tests/FileAsDatabase/XmlCreateTableTests.cs
@@ -16,4 +16,13 @@ public class XmlCreateTableTests
                        () => new XmlConnection(ConnectionStrings.Instance.FileAsDB.Sandbox("Sandbox", sandboxId)));
 
     }
+
+    [Fact]
+    public void CreateTable_FollowedByInsert_ShouldWork()
+    {
+        var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+        CreateTableTests.CreateTable_FollowedByInsert_ShouldWork(
+                       () => new XmlConnection(ConnectionStrings.Instance.FileAsDB.Sandbox("Sandbox", sandboxId)));
+
+    }
 }

--- a/tests/Data.Xml.Tests/FolderAsDatabase/XmlCreateTableTests.cs
+++ b/tests/Data.Xml.Tests/FolderAsDatabase/XmlCreateTableTests.cs
@@ -17,4 +17,12 @@ public class XmlCreateTableTests
 
     }
 
+    [Fact]
+    public void CreateTable_FollowedByInsert_ShouldWork()
+    {
+        var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+        CreateTableTests.CreateTable_FollowedByInsert_ShouldWork(
+                       () => new XmlConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+
+    }
 }


### PR DESCRIPTION
For JSON, if the table has been created from an empty file, then the columns would not be defined in the table, but in the case of this bug, the CREATE TABLE does define the tables before the first INSERT occurs.