### PR TITLE
Fix: Support Boolean data type in providers SQL syntax

### DIFF
--- a/tests/Data.Tests.Common/InsertTests.cs
+++ b/tests/Data.Tests.Common/InsertTests.cs
@@ -34,7 +34,7 @@ public static class InsertTests
             Assert.True(1 == count, $"SELECTing COUNT(*) for id = {id} didn't yield 1 row.  Rows = {count}");
 
             // Act - Insert a new record into the employees table
-            command = connection.CreateCommand("INSERT INTO employees (name, email, salary, married) VALUES ('Jim Convis', 'johndoe@example.com', 100000, 'true')");
+            command = connection.CreateCommand("INSERT INTO employees (name, email, salary, married) VALUES ('Jim Convis', 'johndoe@example.com', 100000, true)");
             rowsAffected = command.ExecuteNonQuery();
 
             // Assert
@@ -133,10 +133,7 @@ public static class InsertTests
             var marriedColumn = employeesTable.Columns["married"];
             Assert.NotNull(marriedColumn);
 
-            //NOTE:  When https://github.com/Servant-Software-LLC/ADO.NET.FileBased.DataProviders/issues/22 is solved, then 
-            //       this assert will fail, because it needs to have an expectation of:
-            // Assert.Equal(typeof(boolean), marriedColumn.DataType);
-            Assert.Equal(typeof(string), marriedColumn.DataType);
+            Assert.Equal(typeof(bool), marriedColumn.DataType);
         }
 
     }


### PR DESCRIPTION
Fixes #22

## Summary
- The SqlBuildingBlocks grammar (1.0.0.132) already recognizes boolean literals (`true`, `false`, `TRUE`, `FALSE`, etc.) in SQL expressions
- The `FileInsertWriter.GetDataColumnType()` already handles `bool => typeof(bool)`
- Update `InsertTests.Insert_ShouldInsertData` to use unquoted boolean literal `true` instead of string literal `'true'`
- Update assertion to expect `typeof(bool)` for the `married` column

## Test plan
- [ ] `Insert_ShouldInsertData` passes with `true` (boolean literal) instead of `'true'` (string literal)
- [ ] `married` column is now properly typed as `bool` instead of `string`