### PR TITLE
Implement DbConnectionStringBuilder for each provider

### DIFF
--- a/src/Data.Common/Utils/ConnectionString/FileConnectionStringBuilder.cs
+++ b/src/Data.Common/Utils/ConnectionString/FileConnectionStringBuilder.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using System.Data.Common;
+
+namespace Data.Common.Utils.ConnectionString;
+
+public class FileConnectionStringBuilder : DbConnectionStringBuilder
+{
+    public string DataSource
+    {
+        get => ContainsKey("DataSource") ? (string)this["DataSource"] : null;
+        set => this["DataSource"] = value;
+    }
+
+    public LogLevel? LogLevel
+    {
+        get
+        {
+            if (!ContainsKey("LogLevel")) return null;
+            if (Enum.TryParse(this["LogLevel"]?.ToString(), true, out Microsoft.Extensions.Logging.LogLevel level))
+                return level;
+            return null;
+        }
+        set
+        {
+            if (value == null) Remove("LogLevel");
+            else this["LogLevel"] = value.ToString();
+        }
+    }
+
+    public FloatingPointDataType? PreferredFloatingPointDataType
+    {
+        get
+        {
+            if (!ContainsKey("PreferredFloatingPointDataType")) return null;
+            if (Enum.TryParse(this["PreferredFloatingPointDataType"]?.ToString(), true, out FloatingPointDataType fpt))
+                return fpt;
+            return null;
+        }
+        set
+        {
+            if (value == null) Remove("PreferredFloatingPointDataType");
+            else this["PreferredFloatingPointDataType"] = value.ToString();
+        }
+    }
+
+    public bool? CreateIfNotExist
+    {
+        get
+        {
+            if (!ContainsKey("CreateIfNotExist")) return null;
+            if (bool.TryParse(this["CreateIfNotExist"]?.ToString(), out bool b)) return b;
+            return null;
+        }
+        set
+        {
+            if (value == null) Remove("CreateIfNotExist");
+            else this["CreateIfNotExist"] = value.ToString();
+        }
+    }
+}

--- a/src/Data.Csv/ADO.NET/CsvClientFactory.cs
+++ b/src/Data.Csv/ADO.NET/CsvClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using Data.Csv.Utils;
+using System.Data.Common;
 
 namespace System.Data.CsvClient;
 
@@ -19,12 +20,7 @@ public sealed class CsvClientFactory : DbProviderFactory
 
     public override DbConnection CreateConnection() => new CsvConnection();
 
-    /// <summary>
-    /// Intendes to be addressed in future versions.  REF: https://github.com/Servant-Software-LLC/FileBased.DataProviders/issues/74
-    /// </summary>
-    /// <returns></returns>
-    /// <exception cref="NotSupportedException"></exception>
-    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => throw new NotSupportedException("ConnectionStringBuilder is not implemented for this provider.");
+    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => new CsvConnectionStringBuilder();
 
     public override DbDataAdapter CreateDataAdapter() => new CsvDataAdapter();
 

--- a/src/Data.Csv/Utils/CsvConnectionStringBuilder.cs
+++ b/src/Data.Csv/Utils/CsvConnectionStringBuilder.cs
@@ -1,0 +1,5 @@
+using Data.Common.Utils.ConnectionString;
+
+namespace Data.Csv.Utils;
+
+public class CsvConnectionStringBuilder : FileConnectionStringBuilder { }

--- a/src/Data.Json/ADO.NET/JsonClientFactory.cs
+++ b/src/Data.Json/ADO.NET/JsonClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using Data.Json.Utils;
+using System.Data.Common;
 
 namespace System.Data.JsonClient;
 
@@ -19,12 +20,7 @@ public sealed class JsonClientFactory : DbProviderFactory
 
     public override DbConnection CreateConnection() => new JsonConnection();
 
-    /// <summary>
-    /// Intendes to be addressed in future versions.  REF: https://github.com/Servant-Software-LLC/FileBased.DataProviders/issues/74
-    /// </summary>
-    /// <returns></returns>
-    /// <exception cref="NotSupportedException"></exception>
-    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => throw new NotSupportedException("ConnectionStringBuilder is not implemented for this provider.");
+    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => new JsonConnectionStringBuilder();
 
     public override DbDataAdapter CreateDataAdapter() => new JsonDataAdapter();
 

--- a/src/Data.Json/Utils/JsonConnectionStringBuilder.cs
+++ b/src/Data.Json/Utils/JsonConnectionStringBuilder.cs
@@ -1,0 +1,21 @@
+using Data.Common.Utils.ConnectionString;
+
+namespace Data.Json.Utils;
+
+public class JsonConnectionStringBuilder : FileConnectionStringBuilder
+{
+    public bool? Formatted
+    {
+        get
+        {
+            if (!ContainsKey("Formatted")) return null;
+            if (bool.TryParse(this["Formatted"]?.ToString(), out bool b)) return b;
+            return null;
+        }
+        set
+        {
+            if (value == null) Remove("Formatted");
+            else this["Formatted"] = value.ToString();
+        }
+    }
+}

--- a/src/Data.Xls/ADO.NET/XlsClientFactory.cs
+++ b/src/Data.Xls/ADO.NET/XlsClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using Data.Xls.Utils;
+using System.Data.Common;
 
 namespace System.Data.XlsClient;
 
@@ -19,12 +20,7 @@ public sealed class XlsClientFactory : DbProviderFactory
 
     public override DbConnection CreateConnection() => new XlsConnection();
 
-    /// <summary>
-    /// Intendes to be addressed in future versions.  REF: https://github.com/Servant-Software-LLC/FileBased.DataProviders/issues/74
-    /// </summary>
-    /// <returns></returns>
-    /// <exception cref="NotSupportedException"></exception>
-    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => throw new NotSupportedException("ConnectionStringBuilder is not implemented for this provider.");
+    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => new XlsConnectionStringBuilder();
 
     public override DbDataAdapter CreateDataAdapter() => throw new InvalidOperationException("The XSL provider does not support adapters.");
 

--- a/src/Data.Xls/Utils/XlsConnectionStringBuilder.cs
+++ b/src/Data.Xls/Utils/XlsConnectionStringBuilder.cs
@@ -1,0 +1,5 @@
+using Data.Common.Utils.ConnectionString;
+
+namespace Data.Xls.Utils;
+
+public class XlsConnectionStringBuilder : FileConnectionStringBuilder { }

--- a/src/Data.Xml/ADO.NET/XmlClientFactory.cs
+++ b/src/Data.Xml/ADO.NET/XmlClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using Data.Xml.Utils;
+using System.Data.Common;
 
 namespace System.Data.XmlClient;
 
@@ -19,12 +20,7 @@ public sealed class XmlClientFactory : DbProviderFactory
 
     public override DbConnection CreateConnection() => new XmlConnection();
 
-    /// <summary>
-    /// Intendes to be addressed in future versions.  REF: https://github.com/Servant-Software-LLC/FileBased.DataProviders/issues/74
-    /// </summary>
-    /// <returns></returns>
-    /// <exception cref="NotSupportedException"></exception>
-    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => throw new NotSupportedException("ConnectionStringBuilder is not implemented for this provider.");
+    public override DbConnectionStringBuilder CreateConnectionStringBuilder() => new XmlConnectionStringBuilder();
 
     public override DbDataAdapter CreateDataAdapter() => new XmlDataAdapter();
 

--- a/src/Data.Xml/Utils/XmlConnectionStringBuilder.cs
+++ b/src/Data.Xml/Utils/XmlConnectionStringBuilder.cs
@@ -1,0 +1,5 @@
+using Data.Common.Utils.ConnectionString;
+
+namespace Data.Xml.Utils;
+
+public class XmlConnectionStringBuilder : FileConnectionStringBuilder { }

--- a/tests/Data.Csv.Tests/FolderAsDatabase/CsvConnectionStringBuilderTests.cs
+++ b/tests/Data.Csv.Tests/FolderAsDatabase/CsvConnectionStringBuilderTests.cs
@@ -1,0 +1,25 @@
+using Data.Csv.Utils;
+using Data.Tests.Common;
+using System.Data.CsvClient;
+using Xunit;
+
+namespace Data.Csv.Tests.FolderAsDatabase;
+
+public class CsvConnectionStringBuilderTests
+{
+    [Fact]
+    public void ConnectionStringBuilder_CanBuildAndParse()
+    {
+        ConnectionStringBuilderTests.ConnectionStringBuilder_CanBuildAndParse(
+            new CsvConnectionStringBuilder(),
+            "/path/to/folder");
+    }
+
+    [Fact]
+    public void Factory_CreateConnectionStringBuilder_ReturnsCsvBuilder()
+    {
+        var factory = CsvClientFactory.Instance;
+        var builder = factory.CreateConnectionStringBuilder();
+        Assert.IsType<CsvConnectionStringBuilder>(builder);
+    }
+}

--- a/tests/Data.Json.Tests/FolderAsDatabase/JsonConnectionStringBuilderTests.cs
+++ b/tests/Data.Json.Tests/FolderAsDatabase/JsonConnectionStringBuilderTests.cs
@@ -1,0 +1,39 @@
+using Data.Json.Utils;
+using Data.Tests.Common;
+using System.Data.JsonClient;
+using Xunit;
+
+namespace Data.Json.Tests.FolderAsDatabase;
+
+public class JsonConnectionStringBuilderTests
+{
+    [Fact]
+    public void ConnectionStringBuilder_CanBuildAndParse()
+    {
+        ConnectionStringBuilderTests.ConnectionStringBuilder_CanBuildAndParse(
+            new JsonConnectionStringBuilder(),
+            "/path/to/database.json");
+    }
+
+    [Fact]
+    public void JsonConnectionStringBuilder_Formatted_Property()
+    {
+        var builder = new JsonConnectionStringBuilder();
+        builder.DataSource = "/path/to/database.json";
+        builder.Formatted = true;
+
+        var cs = builder.ConnectionString;
+        var builder2 = new JsonConnectionStringBuilder();
+        builder2.ConnectionString = cs;
+
+        Assert.Equal(true, builder2.Formatted);
+    }
+
+    [Fact]
+    public void Factory_CreateConnectionStringBuilder_ReturnsJsonBuilder()
+    {
+        var factory = JsonClientFactory.Instance;
+        var builder = factory.CreateConnectionStringBuilder();
+        Assert.IsType<JsonConnectionStringBuilder>(builder);
+    }
+}

--- a/tests/Data.Tests.Common/ConnectionStringBuilderTests.cs
+++ b/tests/Data.Tests.Common/ConnectionStringBuilderTests.cs
@@ -1,0 +1,25 @@
+using Data.Common.Utils.ConnectionString;
+using System.Data.Common;
+using Xunit;
+
+namespace Data.Tests.Common;
+
+public static class ConnectionStringBuilderTests
+{
+    public static void ConnectionStringBuilder_CanBuildAndParse(DbConnectionStringBuilder builder, string dataSource)
+    {
+        // Arrange
+        var fileBuilder = (FileConnectionStringBuilder)builder;
+        fileBuilder.DataSource = dataSource;
+        fileBuilder.CreateIfNotExist = true;
+
+        // Act - round trip through connection string
+        var connectionString = fileBuilder.ConnectionString;
+        var newBuilder = (FileConnectionStringBuilder)Activator.CreateInstance(builder.GetType())!;
+        newBuilder.ConnectionString = connectionString;
+
+        // Assert
+        Assert.Equal(dataSource, newBuilder.DataSource);
+        Assert.Equal(true, newBuilder.CreateIfNotExist);
+    }
+}


### PR DESCRIPTION
Fixes #74

## Summary
- Add `FileConnectionStringBuilder` in `Data.Common` inheriting from `DbConnectionStringBuilder` with properties: `DataSource`, `LogLevel`, `PreferredFloatingPointDataType`, `CreateIfNotExist`
- Add `JsonConnectionStringBuilder` with the JSON-specific `Formatted` property (as noted in the issue, `Formatted` is only for JSON)
- Add `CsvConnectionStringBuilder`, `XmlConnectionStringBuilder`, `XlsConnectionStringBuilder` as provider-specific subclasses
- Update all four `*ClientFactory.CreateConnectionStringBuilder()` methods to return the appropriate builder instead of throwing `NotSupportedException`
- Add tests verifying round-trip connection string building/parsing and factory method return types

## Test plan
- [ ] `FileConnectionStringBuilder` properties round-trip correctly through `ConnectionString`
- [ ] `JsonConnectionStringBuilder.Formatted` property works correctly
- [ ] Each factory's `CreateConnectionStringBuilder()` returns the correct provider-specific type

🤖 Generated with [Claude Code](https://claude.com/claude-code)