### PR TITLE
Add CODEOWNERS — @DaveRMaltby as global owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — @DaveRMaltby is the global code owner
+* @DaveRMaltby


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file to the repository
- Sets `@DaveRMaltby` as the global code owner for all files (`*`)

## Test plan
- [ ] Verify the CODEOWNERS file appears correctly in the repository
- [ ] Confirm GitHub recognizes `@DaveRMaltby` as the required reviewer on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)