### PR TITLE
fix: resolve CA2022 build warning

### DIFF
--- a/tests/Data.Json.Tests/Utils/BOMHandlingStreamTests.cs
+++ b/tests/Data.Json.Tests/Utils/BOMHandlingStreamTests.cs
@@ -108,9 +108,10 @@ namespace Data.Json.Tests.Utils
             var buffer = new byte[5];
 
             // Act
-            bomStream.Read(buffer, 0, buffer.Length);
+            int bytesRead = bomStream.Read(buffer, 0, buffer.Length);
 
             // Assert
+            Assert.Equal(5, bytesRead);
             Assert.Equal(5, bomStream.Position);
         }
 


### PR DESCRIPTION
## Summary
- Fix CA2022 analyzer warning in `BOMHandlingStreamTests.cs` by capturing and asserting the return value of `Stream.Read()`
- Build now compiles with 0 warnings

## Test plan
- [x] `dotnet build` produces 0 warnings
- [x] All 17 BOMHandling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)