### PR TITLE
chore: treat warnings as errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <DefaultArtifactsFileMatch>*.nupkg *.snupkg</DefaultArtifactsFileMatch>
     <DelaySign>false</DelaySign>
     <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' == 'true'">


### PR DESCRIPTION
## Summary
- Adds `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to `Directory.Build.props`
- Any future compiler warning will now fail the build across all projects

## Test plan
- [x] `dotnet build` passes with 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)