### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v3 to v4
- Upgrade `actions/setup-dotnet` from v2 to v4
- Other actions (`upload-artifact@v4`, `codecov-action@v4`) already at latest major versions

Addresses Node.js 20 deprecation warnings — Node.js 24 becomes mandatory June 2, 2026.

## Test plan
- [x] CI build passes with updated action versions

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)