### PR TITLE
chore: force Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   BuildConfiguration: Release
   DataCommonPackageId: ServantSoftware.Data.Common
   DataJsonPackageId: ServantSoftware.Data.Json
@@ -98,7 +99,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       if: github.event_name == 'pull_request'
       with:
         recreate: true


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to opt into Node.js 24 runtime
- Upgrade `marocchino/sticky-pull-request-comment` from v2 to v3

Eliminates Node.js 20 deprecation warnings ahead of the June 2, 2026 deadline.

## Test plan
- [x] CI build passes with Node.js 24 runtime

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)