### PR TITLE
feat: wire up DbProviderFactory property and registration (#125, #126)

### DIFF
--- a/tests/Data.Csv.Tests/FolderAsDatabase/CsvClientFactoryTests.cs
+++ b/tests/Data.Csv.Tests/FolderAsDatabase/CsvClientFactoryTests.cs
@@ -11,4 +11,11 @@ public class CsvClientFactoryTests
     {
         ClientFactoryTests.CreateCommand_ReadsData(CsvClientFactory.Instance);
     }
+
+    [Fact]
+    public void GetFactory_FromConnection_ReturnsCsvClientFactory()
+    {
+        using var connection = new CsvConnection();
+        ClientFactoryTests.GetFactory_FromConnection_ReturnsSameInstance(connection, CsvClientFactory.Instance);
+    }
 }

--- a/tests/Data.Json.Tests/FolderAsDatabase/JsonClientFactoryTests.cs
+++ b/tests/Data.Json.Tests/FolderAsDatabase/JsonClientFactoryTests.cs
@@ -12,4 +12,10 @@ public class JsonClientFactoryTests
         ClientFactoryTests.CreateCommand_ReadsData(JsonClientFactory.Instance);
     }
 
+    [Fact]
+    public void GetFactory_FromConnection_ReturnsJsonClientFactory()
+    {
+        using var connection = new JsonConnection();
+        ClientFactoryTests.GetFactory_FromConnection_ReturnsSameInstance(connection, JsonClientFactory.Instance);
+    }
 }

--- a/tests/Data.Tests.Common/ClientFactoryTests.cs
+++ b/tests/Data.Tests.Common/ClientFactoryTests.cs
@@ -25,4 +25,14 @@ public static class ClientFactoryTests
         // Assert
         Assert.True(reader.HasRows);
     }
+
+    public static void GetFactory_FromConnection_ReturnsSameInstance(DbConnection connection, DbProviderFactory expectedFactory)
+    {
+        // Act
+        var factory = DbProviderFactories.GetFactory(connection);
+
+        // Assert
+        Assert.NotNull(factory);
+        Assert.Same(expectedFactory, factory);
+    }
 }

--- a/tests/Data.Xls.Tests/XlsClientFactoryTests.cs
+++ b/tests/Data.Xls.Tests/XlsClientFactoryTests.cs
@@ -1,0 +1,15 @@
+using Data.Tests.Common;
+using System.Data.XlsClient;
+using Xunit;
+
+namespace Data.Xls.Tests;
+
+public class XlsClientFactoryTests
+{
+    [Fact]
+    public void GetFactory_FromConnection_ReturnsXlsClientFactory()
+    {
+        using var connection = new XlsConnection();
+        ClientFactoryTests.GetFactory_FromConnection_ReturnsSameInstance(connection, XlsClientFactory.Instance);
+    }
+}

--- a/tests/Data.Xml.Tests/FolderAsDatabase/XmlClientFactoryTests.cs
+++ b/tests/Data.Xml.Tests/FolderAsDatabase/XmlClientFactoryTests.cs
@@ -12,4 +12,10 @@ public class XmlClientFactoryTests
         ClientFactoryTests.CreateCommand_ReadsData(XmlClientFactory.Instance);
     }
 
+    [Fact]
+    public void GetFactory_FromConnection_ReturnsXmlClientFactory()
+    {
+        using var connection = new XmlConnection();
+        ClientFactoryTests.GetFactory_FromConnection_ReturnsSameInstance(connection, XmlClientFactory.Instance);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `GetFactory` tests verifying `DbProviderFactories.GetFactory(connection)` returns the correct factory singleton for all four providers (Csv, Json, Xml, Xls)
- DbProviderFactory property overrides and registration were already wired up in d0507d0; this PR adds the missing test coverage

Closes #125, Closes #126

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test --filter "GetFactory"` — all 4 tests pass (Csv, Json, Xml, Xls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>