### PR TITLE
feat: support Insert/Delete in DbDataAdapter.Update() (#124)

### DIFF
--- a/src/Data.Common/ADO.NET/FileDataAdapter.cs
+++ b/src/Data.Common/ADO.NET/FileDataAdapter.cs
@@ -225,19 +225,8 @@ public abstract class FileDataAdapter<TFileParameter> : DbDataAdapter, IFileData
         if (dataSet.Tables.Count == 0)
             throw new InvalidOperationException($"{nameof(dataSet)} does not contain any tables.");
 
-        if (UpdateCommand == null)
-            throw new InvalidOperationException($"Update requires a valid UpdateCommand when passed DataRow collection with modified rows.");
-
-        if (UpdateCommand.Connection == null)
-            throw new InvalidOperationException($"Update requires the UpdateCommand to have a connection object. The Connection property of the UpdateCommand has not been initialized.");
-
-        if (string.IsNullOrEmpty(UpdateCommand.CommandText))
-            throw new InvalidOperationException($"{nameof(UpdateCommand.CommandText)} property on {nameof(UpdateCommand)} is not set.");
-
         if (Connection.AdminMode)
             throw new ArgumentException($"The {GetType()} cannot be used with an admin connection.");
-
-        log.LogInformation($"{GetType()}.{nameof(Update)}() called.  UpdateCommand.CommandText = {UpdateCommand.CommandText}");
 
         DataTable dataTable;
         if (TableMappings.Count > 0 && TableMappings.Contains("Table"))
@@ -250,36 +239,107 @@ public abstract class FileDataAdapter<TFileParameter> : DbDataAdapter, IFileData
         {
             dataTable = dataSet.Tables[0];
         }
-        var changedDataRows = dataTable.Rows.Cast<DataRow>().Where(row => row.RowState == DataRowState.Modified).ToList();
+
         int rowsAffected = 0;
-        foreach (DataRow changedDataRow in changedDataRows)
+
+        // Handle Added rows via InsertCommand
+        var addedRows = dataTable.Rows.Cast<DataRow>().Where(row => row.RowState == DataRowState.Added).ToList();
+        if (addedRows.Count > 0)
         {
-            //check if source column is set and has parameters
-            if (UpdateCommand.Parameters.Count > 0)
+            if (InsertCommand == null)
+                throw new InvalidOperationException("Update requires a valid InsertCommand when passed DataRow collection with added rows.");
+            if (InsertCommand.Connection == null)
+                throw new InvalidOperationException("Update requires the InsertCommand to have a connection object. The Connection property of the InsertCommand has not been initialized.");
+            if (string.IsNullOrEmpty(InsertCommand.CommandText))
+                throw new InvalidOperationException($"{nameof(InsertCommand.CommandText)} property on {nameof(InsertCommand)} is not set.");
+
+            log.LogInformation($"{GetType()}.{nameof(Update)}() called.  InsertCommand.CommandText = {InsertCommand.CommandText}");
+
+            foreach (DataRow addedRow in addedRows)
             {
-                foreach (IDbDataParameter parameter in UpdateCommand.Parameters)
-                {
-                    if (!string.IsNullOrEmpty(parameter.SourceColumn))
-                    {
-                        if (!dataTable.Columns.Contains(parameter.SourceColumn))
-                            throw new InvalidOperationException($"The source column '{parameter.SourceColumn}' does not exist in the DataTable passed into the Update method.");
+                SetParameterValues(InsertCommand, dataTable, addedRow);
 
-                        parameter.Value = changedDataRow[parameter.SourceColumn];
-                    }
-                }
+                var query = FileStatementCreator.Create((FileCommand<TFileParameter>)InsertCommand, log);
+                if (query is not FileInsert)
+                    throw new QueryNotSupportedException("InsertCommand did not produce a valid INSERT statement.");
+
+                var writer = CreateWriter(query);
+                rowsAffected += writer.Execute();
             }
+        }
 
-            var query = FileStatementCreator.Create((FileCommand<TFileParameter>)UpdateCommand, log);
-            if (query is not FileUpdate updateStatement)
+        // Handle Modified rows via UpdateCommand
+        var modifiedRows = dataTable.Rows.Cast<DataRow>().Where(row => row.RowState == DataRowState.Modified).ToList();
+        if (modifiedRows.Count > 0)
+        {
+            if (UpdateCommand == null)
+                throw new InvalidOperationException("Update requires a valid UpdateCommand when passed DataRow collection with modified rows.");
+            if (UpdateCommand.Connection == null)
+                throw new InvalidOperationException("Update requires the UpdateCommand to have a connection object. The Connection property of the UpdateCommand has not been initialized.");
+            if (string.IsNullOrEmpty(UpdateCommand.CommandText))
+                throw new InvalidOperationException($"{nameof(UpdateCommand.CommandText)} property on {nameof(UpdateCommand)} is not set.");
+
+            log.LogInformation($"{GetType()}.{nameof(Update)}() called.  UpdateCommand.CommandText = {UpdateCommand.CommandText}");
+
+            foreach (DataRow modifiedRow in modifiedRows)
             {
-                throw new QueryNotSupportedException("This query is not yet supported via DataAdapter");
-            }
+                SetParameterValues(UpdateCommand, dataTable, modifiedRow);
 
-            var updater = CreateWriter(query);
-            rowsAffected += updater.Execute();
+                var query = FileStatementCreator.Create((FileCommand<TFileParameter>)UpdateCommand, log);
+                if (query is not FileUpdate)
+                    throw new QueryNotSupportedException("UpdateCommand did not produce a valid UPDATE statement.");
+
+                var writer = CreateWriter(query);
+                rowsAffected += writer.Execute();
+            }
+        }
+
+        // Handle Deleted rows via DeleteCommand
+        var deletedRows = dataTable.Rows.Cast<DataRow>().Where(row => row.RowState == DataRowState.Deleted).ToList();
+        if (deletedRows.Count > 0)
+        {
+            if (DeleteCommand == null)
+                throw new InvalidOperationException("Update requires a valid DeleteCommand when passed DataRow collection with deleted rows.");
+            if (DeleteCommand.Connection == null)
+                throw new InvalidOperationException("Update requires the DeleteCommand to have a connection object. The Connection property of the DeleteCommand has not been initialized.");
+            if (string.IsNullOrEmpty(DeleteCommand.CommandText))
+                throw new InvalidOperationException($"{nameof(DeleteCommand.CommandText)} property on {nameof(DeleteCommand)} is not set.");
+
+            log.LogInformation($"{GetType()}.{nameof(Update)}() called.  DeleteCommand.CommandText = {DeleteCommand.CommandText}");
+
+            foreach (DataRow deletedRow in deletedRows)
+            {
+                SetParameterValues(DeleteCommand, dataTable, deletedRow, useOriginalVersion: true);
+
+                var query = FileStatementCreator.Create((FileCommand<TFileParameter>)DeleteCommand, log);
+                if (query is not FileDelete)
+                    throw new QueryNotSupportedException("DeleteCommand did not produce a valid DELETE statement.");
+
+                var writer = CreateWriter(query);
+                rowsAffected += writer.Execute();
+            }
         }
 
         return rowsAffected;
+    }
+
+    private static void SetParameterValues(DbCommand command, DataTable dataTable, DataRow row, bool useOriginalVersion = false)
+    {
+        if (command.Parameters.Count == 0)
+            return;
+
+        foreach (IDbDataParameter parameter in command.Parameters)
+        {
+            if (!string.IsNullOrEmpty(parameter.SourceColumn))
+            {
+                if (!dataTable.Columns.Contains(parameter.SourceColumn))
+                    throw new InvalidOperationException($"The source column '{parameter.SourceColumn}' does not exist in the DataTable passed into the Update method.");
+
+                parameter.Value = useOriginalVersion
+                    ? row[parameter.SourceColumn, DataRowVersion.Original]
+                    : row[parameter.SourceColumn];
+            }
+        }
     }
 
     /// <summary>

--- a/src/Data.Csv/ADO.NET/CsvDataAdapter.cs
+++ b/src/Data.Csv/ADO.NET/CsvDataAdapter.cs
@@ -32,12 +32,10 @@ public class CsvDataAdapter : FileDataAdapter<CsvParameter>
     /// <inheritdoc/>
     protected override FileWriter CreateWriter(FileStatement fileStatement) => fileStatement switch
     {
-        //TODO: Is it a bug that for the deleteStatement, the UpdateCommand is used instead of the DeleteCommand? (both to get the connection and the FileCommand)
         global::Data.Common.FileStatements.FileDelete deleteStatement =>
-            new CsvDelete(deleteStatement, (CsvConnection)UpdateCommand!.Connection!, (FileCommand<CsvParameter>)UpdateCommand),
-        //TODO: Is it a bug that for the insertStatement, the UpdateCommand is used instead of the DeleteCommand? (both to get the connection and the FileCommand)
+            new CsvDelete(deleteStatement, (CsvConnection)DeleteCommand!.Connection!, (FileCommand<CsvParameter>)DeleteCommand),
         global::Data.Common.FileStatements.FileInsert insertStatement =>
-            new CsvInsert(insertStatement, (CsvConnection)UpdateCommand!.Connection!, (FileCommand<CsvParameter>)UpdateCommand),
+            new CsvInsert(insertStatement, (CsvConnection)InsertCommand!.Connection!, (FileCommand<CsvParameter>)InsertCommand),
         global::Data.Common.FileStatements.FileUpdate updateStatement =>
             new CsvUpdate(updateStatement, (CsvConnection)UpdateCommand!.Connection!, (FileCommand<CsvParameter>)UpdateCommand),
 

--- a/src/Data.Json/ADO.NET/JsonDataAdapter.cs
+++ b/src/Data.Json/ADO.NET/JsonDataAdapter.cs
@@ -27,8 +27,8 @@ public class JsonDataAdapter : FileDataAdapter<JsonParameter>
     /// <inheritdoc/>
     protected override FileWriter CreateWriter(FileStatement fileStatement) => fileStatement switch
     {
-        global::Data.Common.FileStatements.FileDelete deleteStatement => new JsonDelete(deleteStatement, (JsonConnection)UpdateCommand!.Connection!, (FileCommand<JsonParameter>)UpdateCommand),
-        FileInsert insertStatement => new JsonInsert(insertStatement, (JsonConnection)UpdateCommand!.Connection!, (FileCommand<JsonParameter>)UpdateCommand),
+        global::Data.Common.FileStatements.FileDelete deleteStatement => new JsonDelete(deleteStatement, (JsonConnection)DeleteCommand!.Connection!, (FileCommand<JsonParameter>)DeleteCommand),
+        FileInsert insertStatement => new JsonInsert(insertStatement, (JsonConnection)InsertCommand!.Connection!, (FileCommand<JsonParameter>)InsertCommand),
         FileUpdate updateStatement => new JsonUpdate(updateStatement, (JsonConnection)UpdateCommand!.Connection!, (FileCommand<JsonParameter>)UpdateCommand),
 
         _ => throw new InvalidOperationException("query not supported")

--- a/src/Data.Xml/ADO.NET/XmlDataAdapter.cs
+++ b/src/Data.Xml/ADO.NET/XmlDataAdapter.cs
@@ -32,8 +32,8 @@ public class XmlDataAdapter : FileDataAdapter<XmlParameter>
     /// <exception cref="InvalidOperationException">Thrown when the query type is not supported.</exception>
     protected override FileWriter CreateWriter(FileStatement fileStatement) => fileStatement switch
     {
-        global::Data.Common.FileStatements.FileDelete deleteStatement => new XmlDelete(deleteStatement, (XmlConnection)UpdateCommand!.Connection!, (FileCommand<XmlParameter>)UpdateCommand),
-        global::Data.Common.FileStatements.FileInsert insertStatement => new XmlInsert(insertStatement, (XmlConnection)UpdateCommand!.Connection!, (FileCommand<XmlParameter>)UpdateCommand),
+        global::Data.Common.FileStatements.FileDelete deleteStatement => new XmlDelete(deleteStatement, (XmlConnection)DeleteCommand!.Connection!, (FileCommand<XmlParameter>)DeleteCommand),
+        global::Data.Common.FileStatements.FileInsert insertStatement => new XmlInsert(insertStatement, (XmlConnection)InsertCommand!.Connection!, (FileCommand<XmlParameter>)InsertCommand),
         global::Data.Common.FileStatements.FileUpdate updateStatement => new XmlUpdate(updateStatement, (XmlConnection)UpdateCommand!.Connection!, (FileCommand<XmlParameter>)UpdateCommand),
 
         _ => throw new InvalidOperationException("query not supported")

--- a/tests/Data.Csv.Tests/FolderAsDatabase/CsvDataAdapterTests.cs
+++ b/tests/Data.Csv.Tests/FolderAsDatabase/CsvDataAdapterTests.cs
@@ -152,6 +152,30 @@ namespace Data.Csv.Tests.FolderAsDatabase
         }
 
         [Fact]
+        public void Update_DataAdapter_Should_Insert_Added_Row()
+        {
+            var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+            DataAdapterTests.Update_DataAdapter_Should_Insert_Added_Row(
+                () => new CsvConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+        }
+
+        [Fact]
+        public void Update_DataAdapter_Should_Delete_Deleted_Row()
+        {
+            var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+            DataAdapterTests.Update_DataAdapter_Should_Delete_Deleted_Row(
+                () => new CsvConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+        }
+
+        [Fact]
+        public void Update_DataAdapter_Should_Handle_Mixed_RowStates()
+        {
+            var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";
+            DataAdapterTests.Update_DataAdapter_Should_Handle_Mixed_RowStates(
+                () => new CsvConnection(ConnectionStrings.Instance.FolderAsDB.Sandbox("Sandbox", sandboxId)));
+        }
+
+        [Fact]
         public void Update_WithTableMapping_ShouldUseCorrectTable()
         {
             var sandboxId = $"{GetType().FullName}.{MethodBase.GetCurrentMethod()!.Name}";

--- a/tests/Data.Tests.Common/DataAdapterTests.cs
+++ b/tests/Data.Tests.Common/DataAdapterTests.cs
@@ -572,6 +572,196 @@ SELECT [c].[CustomerName], [o].[OrderDate], [oi].[Quantity], [p].[Name]
         connection.Close();
     }
 
+    public static void Update_DataAdapter_Should_Insert_Added_Row<TFileParameter>(Func<FileConnection<TFileParameter>> createFileConnection)
+        where TFileParameter : FileParameter<TFileParameter>, new()
+    {
+        // Arrange
+        var connection = createFileConnection();
+        connection.Open();
+
+        var selectCommand = connection.CreateCommand("SELECT city, state, zip FROM locations");
+        var adapter = selectCommand.CreateAdapter();
+        var dataSet = new DataSet();
+        adapter.Fill(dataSet);
+
+        var dataTable = dataSet.Tables[0];
+
+        // Add a new row to the DataTable
+        var newRow = dataTable.NewRow();
+        newRow["city"] = "Portland";
+        newRow["state"] = "OR";
+        newRow["zip"] = 97201;
+        dataTable.Rows.Add(newRow);
+        Assert.Equal(DataRowState.Added, newRow.RowState);
+
+        // Act - set up InsertCommand with parameterized query
+        var insertCommand = connection.CreateCommand("INSERT INTO locations (city, state, zip) VALUES (@city, @state, @zip)");
+        var cityParam = insertCommand.CreateParameter("city", DbType.String);
+        cityParam.SourceColumn = "city";
+        insertCommand.Parameters.Add(cityParam);
+        var stateParam = insertCommand.CreateParameter("state", DbType.String);
+        stateParam.SourceColumn = "state";
+        insertCommand.Parameters.Add(stateParam);
+        var zipParam = insertCommand.CreateParameter("zip", DbType.Int32);
+        zipParam.SourceColumn = "zip";
+        insertCommand.Parameters.Add(zipParam);
+        adapter.InsertCommand = insertCommand;
+        int rowsAffected = adapter.Update(dataSet);
+
+        // Assert
+        Assert.Equal(1, rowsAffected);
+
+        // Verify the row was actually inserted
+        var verifyDataSet = new DataSet();
+        var verifyCommand = connection.CreateCommand("SELECT city, state, zip FROM locations WHERE city = 'Portland'");
+        var verifyAdapter = verifyCommand.CreateAdapter();
+        verifyAdapter.Fill(verifyDataSet);
+
+        Assert.Equal(1, verifyDataSet.Tables[0].Rows.Count);
+        var row = verifyDataSet.Tables[0].Rows[0];
+        Assert.Equal("Portland", row["city"]);
+        Assert.Equal("OR", row["state"]);
+        Assert.Equal(connection.GetProperlyTypedValue(97201), row["zip"]);
+
+        connection.Close();
+    }
+
+    public static void Update_DataAdapter_Should_Delete_Deleted_Row<TFileParameter>(Func<FileConnection<TFileParameter>> createFileConnection)
+        where TFileParameter : FileParameter<TFileParameter>, new()
+    {
+        // Arrange
+        var connection = createFileConnection();
+        connection.Open();
+
+        // Insert a row that we'll later delete via the adapter
+        var insertCommand = connection.CreateCommand("INSERT INTO locations (city, state, zip) VALUES ('Deleteville', 'DL', 99999)");
+        insertCommand.ExecuteNonQuery();
+
+        var selectCommand = connection.CreateCommand("SELECT city, state, zip FROM locations");
+        var adapter = selectCommand.CreateAdapter();
+        var dataSet = new DataSet();
+        adapter.Fill(dataSet);
+
+        // Find and delete the row we just inserted
+        DataRow? targetRow = null;
+        foreach (DataRow r in dataSet.Tables[0].Rows)
+        {
+            if (r["city"].ToString() == "Deleteville")
+            {
+                targetRow = r;
+                break;
+            }
+        }
+        Assert.NotNull(targetRow);
+        targetRow.Delete();
+        Assert.Equal(DataRowState.Deleted, targetRow.RowState);
+
+        // Act - set up DeleteCommand with parameterized query
+        var deleteCommand = connection.CreateCommand("DELETE FROM locations WHERE city = @city");
+        var cityParam = deleteCommand.CreateParameter("city", DbType.String);
+        cityParam.SourceColumn = "city";
+        deleteCommand.Parameters.Add(cityParam);
+        adapter.DeleteCommand = deleteCommand;
+        int rowsAffected = adapter.Update(dataSet);
+
+        // Assert
+        Assert.Equal(1, rowsAffected);
+
+        // Verify the row was actually deleted
+        var verifyDataSet = new DataSet();
+        var verifyCommand = connection.CreateCommand("SELECT city, state, zip FROM locations WHERE city = 'Deleteville'");
+        var verifyAdapter = verifyCommand.CreateAdapter();
+        verifyAdapter.Fill(verifyDataSet);
+
+        Assert.Equal(0, verifyDataSet.Tables[0].Rows.Count);
+
+        connection.Close();
+    }
+
+    public static void Update_DataAdapter_Should_Handle_Mixed_RowStates<TFileParameter>(Func<FileConnection<TFileParameter>> createFileConnection)
+        where TFileParameter : FileParameter<TFileParameter>, new()
+    {
+        // Arrange
+        var connection = createFileConnection();
+        connection.Open();
+
+        // Insert rows to modify/delete later
+        connection.CreateCommand("INSERT INTO locations (city, state, zip) VALUES ('ToDelete', 'TD', 11111)").ExecuteNonQuery();
+        connection.CreateCommand("INSERT INTO locations (city, state, zip) VALUES ('ToModify', 'TM', 22222)").ExecuteNonQuery();
+
+        var selectCommand = connection.CreateCommand("SELECT city, state, zip FROM locations");
+        var adapter = selectCommand.CreateAdapter();
+        var dataSet = new DataSet();
+        adapter.Fill(dataSet);
+
+        var dataTable = dataSet.Tables[0];
+
+        // Add a new row
+        var newRow = dataTable.NewRow();
+        newRow["city"] = "NewCity";
+        newRow["state"] = "NC";
+        newRow["zip"] = 33333;
+        dataTable.Rows.Add(newRow);
+
+        // Modify a row
+        DataRow? modifyRow = null;
+        foreach (DataRow r in dataTable.Rows)
+        {
+            if (r["city"].ToString() == "ToModify") { modifyRow = r; break; }
+        }
+        Assert.NotNull(modifyRow);
+        modifyRow["zip"] = 44444;
+
+        // Delete a row
+        DataRow? deleteRow = null;
+        foreach (DataRow r in dataTable.Rows)
+        {
+            if (r["city"].ToString() == "ToDelete") { deleteRow = r; break; }
+        }
+        Assert.NotNull(deleteRow);
+        deleteRow.Delete();
+
+        // Act - set up all three commands
+        var insertCmd = connection.CreateCommand("INSERT INTO locations (city, state, zip) VALUES (@city, @state, @zip)");
+        var p1 = insertCmd.CreateParameter("city", DbType.String); p1.SourceColumn = "city"; insertCmd.Parameters.Add(p1);
+        var p2 = insertCmd.CreateParameter("state", DbType.String); p2.SourceColumn = "state"; insertCmd.Parameters.Add(p2);
+        var p3 = insertCmd.CreateParameter("zip", DbType.Int32); p3.SourceColumn = "zip"; insertCmd.Parameters.Add(p3);
+        adapter.InsertCommand = insertCmd;
+
+        var updateCmd = connection.CreateCommand("UPDATE locations SET zip = @zip WHERE city = @city");
+        var p4 = updateCmd.CreateParameter("city", DbType.String); p4.SourceColumn = "city"; updateCmd.Parameters.Add(p4);
+        var p5 = updateCmd.CreateParameter("zip", DbType.Int32); p5.SourceColumn = "zip"; updateCmd.Parameters.Add(p5);
+        adapter.UpdateCommand = updateCmd;
+
+        var deleteCmd = connection.CreateCommand("DELETE FROM locations WHERE city = @city");
+        var p6 = deleteCmd.CreateParameter("city", DbType.String); p6.SourceColumn = "city"; deleteCmd.Parameters.Add(p6);
+        adapter.DeleteCommand = deleteCmd;
+
+        int rowsAffected = adapter.Update(dataSet);
+
+        // Assert - should have affected 3 rows (1 insert + 1 update + 1 delete)
+        Assert.Equal(3, rowsAffected);
+
+        // Verify insert
+        var verifyInsert = new DataSet();
+        connection.CreateCommand("SELECT * FROM locations WHERE city = 'NewCity'").CreateAdapter().Fill(verifyInsert);
+        Assert.Equal(1, verifyInsert.Tables[0].Rows.Count);
+        Assert.Equal(connection.GetProperlyTypedValue(33333), verifyInsert.Tables[0].Rows[0]["zip"]);
+
+        // Verify update
+        var verifyUpdate = new DataSet();
+        connection.CreateCommand("SELECT * FROM locations WHERE city = 'ToModify'").CreateAdapter().Fill(verifyUpdate);
+        Assert.Equal(1, verifyUpdate.Tables[0].Rows.Count);
+        Assert.Equal(connection.GetProperlyTypedValue(44444), verifyUpdate.Tables[0].Rows[0]["zip"]);
+
+        // Verify delete
+        var verifyDelete = new DataSet();
+        connection.CreateCommand("SELECT * FROM locations WHERE city = 'ToDelete'").CreateAdapter().Fill(verifyDelete);
+        Assert.Equal(0, verifyDelete.Tables[0].Rows.Count);
+
+        connection.Close();
+    }
+
     public static void Update_WithTableMapping_ShouldUseCorrectTable<TFileParameter>(Func<FileConnection<TFileParameter>> createFileConnection)
         where TFileParameter : FileParameter<TFileParameter>, new()
     {


### PR DESCRIPTION
Closes #124

## Summary
- Fix `FileDataAdapter.Update()` to handle all row states: `Added` (executes `InsertCommand`), `Modified` (executes `UpdateCommand`), and `Deleted` (executes `DeleteCommand`)
- Fix `CreateWriter()` in all provider adapters (Csv, Json, Xml) to use the correct command (`InsertCommand`/`DeleteCommand`) instead of always using `UpdateCommand`
- Add tests for insert-via-Update, delete-via-Update, and mixed row states

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — all 537 tests pass (0 failures)
- [x] New tests: insert, delete, and mixed row state scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>