### PR TITLE
Fix FileConnection Dispose/Open lifecycle (#157, #153)

### DIFF
--- a/src/Data.Common/ADO.NET/FileConnection.cs
+++ b/src/Data.Common/ADO.NET/FileConnection.cs
@@ -201,7 +201,6 @@ public abstract class FileConnection<TFileParameter> : DbConnection, IFileConnec
     /// </summary>
     public override void Close()
     {
-        (DataSourceProvider as IDisposable)?.Dispose();
         state = ConnectionState.Closed;
     }
 
@@ -233,6 +232,9 @@ public abstract class FileConnection<TFileParameter> : DbConnection, IFileConnec
     /// </summary>
     public override void Open()
     {
+        if (State == ConnectionState.Open)
+            throw new InvalidOperationException("Connection is already open.");
+
         if (DataSourceProvider is null)
         {
             if (!CreateIfNotExist)
@@ -322,11 +324,15 @@ public abstract class FileConnection<TFileParameter> : DbConnection, IFileConnec
     /// <summary>
     /// Disposes the connection.
     /// </summary>
-    protected new void Dispose()
+    protected override void Dispose(bool disposing)
     {
-        (DataSourceProvider as IDisposable)?.Dispose();
-        base.Dispose();
-        state = ConnectionState.Closed;
+        if (disposing)
+        {
+            (DataSourceProvider as IDisposable)?.Dispose();
+            DataSourceProvider = null;
+            state = ConnectionState.Closed;
+        }
+        base.Dispose(disposing);
     }
 
     private DataTable GetTablesSchema()

--- a/src/Data.Common/ADO.NET/FileDataReader.cs
+++ b/src/Data.Common/ADO.NET/FileDataReader.cs
@@ -85,7 +85,11 @@ public abstract class FileDataReader : DbDataReader
     /// </summary>
     public override bool HasRows => result.HasRows;
 
-    public override void Close() => Dispose();
+    public override void Close()
+    {
+        log.LogDebug($"{GetType()}.{nameof(Close)}() called.");
+        fileReader.Dispose();
+    }
 
     /// <summary>
     /// Advances to the next result, when reading the results of batch SQL statements.
@@ -714,10 +718,9 @@ public abstract class FileDataReader : DbDataReader
     /// <summary>
     /// Disposes of the resources used by this instance.
     /// </summary>
-    protected new void Dispose()
+    protected override void Dispose(bool disposing)
     {
-        log.LogDebug($"{GetType()}.{nameof(Dispose)}() called.");
-        fileReader.Dispose();
+        base.Dispose(disposing);
     }
 
     /// <summary>

--- a/src/Data.Common/ADO.NET/FileTransaction.cs
+++ b/src/Data.Common/ADO.NET/FileTransaction.cs
@@ -115,15 +115,18 @@ public abstract class FileTransaction<TFileParameter> : DbTransaction, IFileTran
 #endif
 
     /// <inheritdoc/>
-    protected new void Dispose()
+    protected override void Dispose(bool disposing)
     {
-        log.LogDebug($"{GetType()}.{nameof(Dispose)}() called.");
+        if (disposing)
+        {
+            log.LogDebug($"{GetType()}.{nameof(Dispose)}() called.");
 
-        if (!TransactionDone)
-            Rollback();
+            if (!TransactionDone)
+                Rollback();
 
-        base.Dispose();
-        Writers.Clear();
+            Writers.Clear();
+        }
+        base.Dispose(disposing);
     }
 
     /// <inheritdoc/>

--- a/tests/Data.Tests.Common/InsertTests.cs
+++ b/tests/Data.Tests.Common/InsertTests.cs
@@ -24,6 +24,7 @@ public static class InsertTests
 
             // Assert
             Assert.Equal(1, rowsAffected);
+            connection.Close();
             connection.Open();
 
             // Act - Verify the inserted record exists in the locations table
@@ -61,6 +62,7 @@ public static class InsertTests
 
             // Assert
             Assert.Equal(1, rowsAffected);
+            connection.Close();
             connection.Open();
 
             // Act - Verify the inserted record exists in the locations table


### PR DESCRIPTION
## Summary
- **#157**: Override `Dispose(bool disposing)` instead of using `protected new void Dispose()` in `FileConnection`, `FileTransaction`, and `FileDataReader` so polymorphic disposal works correctly via base type references (e.g. `using (DbConnection conn = ...)`)
- **#153**: `FileConnection.Open()` now throws `InvalidOperationException` when called on an already-open connection, per ADO.NET contract
- Simplified `Close()` to only transition state; resource cleanup moved to `Dispose(bool)`
- Fixed `FileDataReader` to use `Close()` override for cleanup to avoid recursion with base `DbDataReader.Dispose(bool)` calling `Close()`
- Updated tests to use `Close()` + `Open()` instead of bare re-`Open()` for data refresh

## Test plan
- [x] All CSV tests pass (128/128)
- [x] All JSON tests pass (202/202 + 2 skipped)
- [x] All XML tests pass (154/154)
- [x] All XLS tests pass (34/34 + 5 skipped)
- [x] Custom data source tests pass (StreamedDataSource round-trip)

Closes #157, Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)