### PR TITLE
fix: document SchemaUnknownWithoutData design for XSD edge case

### DIFF
--- a/src/Data.Xml/XmlIO/Write/XmlInsert.cs
+++ b/src/Data.Xml/XmlIO/Write/XmlInsert.cs
@@ -9,6 +9,9 @@ internal class XmlInsert : Common.FileIO.Write.FileInsertWriter
     {
     }
 
+    // Always true: XML schema may or may not come from an XSD file, but the property
+    // doesn't have table context to check. RealizeSchema handles this by returning early
+    // when columns are already defined (e.g. from XSD or CREATE TABLE).
     public override bool SchemaUnknownWithoutData => true;
 
     protected override void RealizeSchema(DataTable dataTable)


### PR DESCRIPTION
## Summary
- Documents why `SchemaUnknownWithoutData` remains hardcoded to `true` in `XmlInsert` rather than dynamically detecting XSD presence
- The property lacks table context to check for XSD; `RealizeSchema` already handles this correctly by returning early when columns are defined (e.g. from XSD or CREATE TABLE)
- Dynamic detection would require architectural changes to the base class (`FileInsertWriter`) with negligible benefit — the overhead is one `ToDataTable()` call in the rare "empty table with XSD" scenario

Closes #156

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings (4 pre-existing warnings in EFCore.Json)
- [x] `dotnet test` — all 557 tests pass (0 failures)
- [x] Verified existing test from Step 2 (`InsertInto_EmptyXmlWithoutXsd_InfersSchemaFromValues`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)