### PR TITLE
TOSCA-52141: Exclude rPh phonetic annotations from shared string values during xlsx import

### DIFF
--- a/src/Data.Xls/Utils/WorkbookExtensions.cs
+++ b/src/Data.Xls/Utils/WorkbookExtensions.cs
@@ -18,7 +18,8 @@ public static class WorkbookExtensions
         if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString)
         {
             var stringTable = workbook.SharedStringTablePart.SharedStringTable;
-            return stringTable.ChildElements[int.Parse(value)].InnerText;
+            var item = (SharedStringItem)stringTable.ChildElements[int.Parse(value)];
+            return GetSharedStringText(item);
         }
 
         if (cell.DataType != null && cell.DataType.Value == CellValues.Boolean)
@@ -31,6 +32,13 @@ public static class WorkbookExtensions
             return dateTimeValue;
 
         return value;
+    }
+
+    private static string GetSharedStringText(SharedStringItem item)
+    {
+        var directText = item.Text?.InnerText ?? string.Empty;
+        var runText = string.Concat(item.Elements<Run>().Select(r => r.Text?.InnerText ?? string.Empty));
+        return directText + runText;
     }
 
     private static bool TryGetDateTimeValue(WorkbookPart workbook, Cell cell, out string dateTimeValue)

--- a/tests/Data.Xls.Tests/Data.Xls.Tests.csproj
+++ b/tests/Data.Xls.Tests/Data.Xls.Tests.csproj
@@ -26,6 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Data.Xls\Data.Xls.csproj" />
     <ProjectReference Include="..\Data.Tests.Common\Data.Tests.Common.csproj" />
   </ItemGroup>

--- a/tests/Data.Xls.Tests/Utils/WorkbookExtensionsTests.cs
+++ b/tests/Data.Xls.Tests/Utils/WorkbookExtensionsTests.cs
@@ -1,0 +1,105 @@
+using Data.Xls.Utils;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using Xunit;
+
+namespace Data.Xls.Tests.Utils;
+
+public class WorkbookExtensionsTests
+{
+    [Fact]
+    public void GetCellValue_ReturnsKanjiText_WhenSharedStringHasNoPhoneticAnnotation()
+    {
+        using var ms = new MemoryStream();
+        using var document = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook);
+        WorkbookPart workbookPart = GivenWorkbookWithSharedString(document,
+            new SharedStringItem(new Text("株式会社ホープス")));
+        Cell cell = GivenSharedStringCell(index: 0);
+
+        string result = workbookPart.GetCellValue(cell);
+
+        ThenResultEquals(result, "株式会社ホープス");
+    }
+
+    [Fact]
+    public void GetCellValue_ExcludesPhoneticAnnotation_WhenSharedStringHasRphElement_RegressionForTOSCA52141()
+    {
+        using var ms = new MemoryStream();
+        using var document = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook);
+        WorkbookPart workbookPart = GivenWorkbookWithPhoneticSharedString(document,
+            kanjiText: "株式会社ホープス",
+            phoneticText: "カブシキガイシャ");
+        Cell cell = GivenSharedStringCell(index: 0);
+
+        string result = workbookPart.GetCellValue(cell);
+
+        ThenResultEquals(result, "株式会社ホープス");
+    }
+
+    [Fact]
+    public void GetCellValue_ConcatenatesRunsAndExcludesPhoneticAnnotation_WhenSharedStringUsesMultipleRuns_RegressionForTOSCA52141()
+    {
+        using var ms = new MemoryStream();
+        using var document = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook);
+        WorkbookPart workbookPart = GivenWorkbookWithMultiRunPhoneticSharedString(document,
+            runTexts: new[] { "株式", "会社ホープス" },
+            phoneticText: "カブシキガイシャホープス");
+        Cell cell = GivenSharedStringCell(index: 0);
+
+        string result = workbookPart.GetCellValue(cell);
+
+        ThenResultEquals(result, "株式会社ホープス");
+    }
+
+    private static WorkbookPart GivenWorkbookWithSharedString(SpreadsheetDocument document, SharedStringItem item)
+    {
+        var workbookPart = document.AddWorkbookPart();
+        var sharedStringPart = workbookPart.AddNewPart<SharedStringTablePart>();
+        var table = new SharedStringTable();
+        table.AppendChild(item);
+        sharedStringPart.SharedStringTable = table;
+        return workbookPart;
+    }
+
+    private static WorkbookPart GivenWorkbookWithPhoneticSharedString(
+        SpreadsheetDocument document, string kanjiText, string phoneticText)
+    {
+        var item = new SharedStringItem();
+        item.AppendChild(new Text(kanjiText));
+        var phoneticRun = new PhoneticRun { BaseTextStartIndex = 0, EndingBaseIndex = (uint)kanjiText.Length };
+        phoneticRun.AppendChild(new Text(phoneticText));
+        item.AppendChild(phoneticRun);
+        return GivenWorkbookWithSharedString(document, item);
+    }
+
+    private static WorkbookPart GivenWorkbookWithMultiRunPhoneticSharedString(
+        SpreadsheetDocument document, string[] runTexts, string phoneticText)
+    {
+        var item = new SharedStringItem();
+        foreach (var runText in runTexts)
+        {
+            var run = new Run();
+            run.AppendChild(new Text(runText));
+            item.AppendChild(run);
+        }
+        var phoneticRun = new PhoneticRun { BaseTextStartIndex = 0, EndingBaseIndex = (uint)string.Concat(runTexts).Length };
+        phoneticRun.AppendChild(new Text(phoneticText));
+        item.AppendChild(phoneticRun);
+        return GivenWorkbookWithSharedString(document, item);
+    }
+
+    private static Cell GivenSharedStringCell(int index)
+    {
+        return new Cell
+        {
+            DataType = CellValues.SharedString,
+            CellValue = new CellValue(index.ToString())
+        };
+    }
+
+    private static void ThenResultEquals(string actual, string expected)
+    {
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
﻿> **Created by:** ElvinSenoymak
> **Manual Verification:** ⚠️ Skipped

## Summary

Fixes [TOSCA-52141](https://tricentis.atlassian.net/browse/TOSCA-52141)

`WorkbookExtensions.GetCellValue` was calling `InnerText` on the `SharedStringItem` element, which recursively concatenates all descendant text including `<rPh>` (ruby/phonetic annotation) elements. For Japanese cells with Excel-generated furigana, this appended the Katakana phonetic reading to the imported value (e.g. `株式会社ホープス` → `株式会社ホープスカブシキガイシャ`). The fix replaces `InnerText` with targeted collection of only `<t>` direct children and `<r><t>` run children, explicitly skipping `PhoneticRun` elements.

## Root Cause

`stringTable.ChildElements[int.Parse(value)].InnerText` at `WorkbookExtensions.GetCellValue:21` — OpenXML SDK's `InnerText` recursively concatenates ALL descendant text nodes in the `<si>` element, including those inside `<rPh>` phonetic annotation children. The correct value is only in `<t>` direct children and `<r><t>` run children.

## Fix Applied

- `src/Data.Xls/Utils/WorkbookExtensions.cs` — replaced `InnerText` on `SharedStringItem` with a new `GetSharedStringText` helper that collects text only from `SharedStringItem.Text` (direct `<t>`) and `SharedStringItem.Elements<Run>()` (run `<r><t>` children), excluding `PhoneticRun` (`<rPh>`) elements entirely
- `tests/Data.Xls.Tests/Data.Xls.Tests.csproj` — added `DocumentFormat.OpenXml` package reference for in-memory spreadsheet construction in tests
- `tests/Data.Xls.Tests/Utils/WorkbookExtensionsTests.cs` — new test class with 3 scenarios

## Acceptance Test Coverage (TOSCA-52141)

[x] Scenario 1 — Kanji-only shared string is returned unchanged (happy path)
    Test:   WorkbookExtensionsTests → "GetCellValue_ReturnsKanjiText_WhenSharedStringHasNoPhoneticAnnotation"
    Commit: e969842

[x] Scenario 2 — Phonetic annotation (<rPh>) is excluded from the returned value
    Test:   WorkbookExtensionsTests → "GetCellValue_ExcludesPhoneticAnnotation_WhenSharedStringHasRphElement_RegressionForTOSCA52141"
    Commit: e969842

[x] Scenario 3 — Multi-run cell with phonetic annotations is assembled correctly
    Test:   WorkbookExtensionsTests → "GetCellValue_ConcatenatesRunsAndExcludesPhoneticAnnotation_WhenSharedStringUsesMultipleRuns_RegressionForTOSCA52141"
    Commit: e969842

Coverage: 3/3 scenarios covered

## For Reviewers — Developer Context

_Preempts the usual questions so this change can be reviewed without a tester walk-through._

**Why this approach:** Used the OpenXML SDK's typed element API (`SharedStringItem.Text`, `Elements<Run>()`) to collect only the semantically correct text nodes, rather than stripping `<rPh>` text after the fact. The `InnerText` approach was not patched with a string replacement because that would be fragile and could corrupt legitimate text that happens to match a phonetic reading.

**Blast radius:** Only `WorkbookExtensions.GetCellValue` is changed. Its single caller is `XlsSheetStream.cs:68`. Non-Japanese / non-annotated cells are unaffected — `SharedStringItem.Text` and `Run.Text` are the standard nodes for all shared strings; `<rPh>` is only present in cells with Excel phonetic annotations.

**What was verified:** 3 unit tests covering the happy path (no annotation), the single-text-node furigana case, and the multi-run furigana case. All 39 existing `Data.Xls.Tests` tests continue to pass.
**Not covered:** Manual import of a real furigana xlsx file against the TDM stack was skipped; CI will serve as the first integration gate.

**Risks & assumptions:** Assumes all xlsx files produced by standard Excel follow the OpenXML spec for shared strings (direct `<t>` or `<r><t>` children, phonetic text in `<rPh>`). Non-standard producers (e.g. LibreOffice) that store phonetic text differently are not expected to be affected, as they typically do not emit `<rPh>` elements at all.

**Start here:** `src/Data.Xls/Utils/WorkbookExtensions.cs` → `GetSharedStringText` — the new private helper is the entire fix.

**Follow-ups:** none

> 🤖 **This fix was AI-generated.** The tester guided the fix and validated its user-visible behaviour (reproduction, pass/fail), and can answer questions about the process, scope, and how it was verified — but they did not author the code and aren't its architect. For implementation or architecture questions beyond the notes above, ask the AI directly (open this PR's diff in Cursor and query it) or loop in a developer; review comments are addressed via the AI as well. Technical ownership of the change sits with a developer or the AI.